### PR TITLE
RFC: Add (non-working) test

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -89,7 +89,7 @@ command = py342.cmd
 [env:3.4.2 x86]
 command = py342_x86.cmd
 
-[pytest]
+[tool:pytest]
 # Folders 'pytest' unit testing framework should avoid when collecting test
 # cases to run, e.g. internal build & version control system folders.
 norecursedirs = .git .hg .svn build dist

--- a/suds/bindings/document.py
+++ b/suds/bindings/document.py
@@ -98,10 +98,11 @@ class Document(Binding):
         return root
 
     def replycontent(self, method, body):
-        if method.soap.output.body.wrapped and body:
+        #if method.soap.output.body.wrapped and body:
+        if method.soap.output.body.wrapped:
             return body[0].children
-        elif method.soap.output.body.wrapped:
-            return []
+        #elif method.soap.output.body.wrapped:
+        #    return []
         return body.children
 
     def document(self, wrapper):

--- a/suds/bindings/document.py
+++ b/suds/bindings/document.py
@@ -98,8 +98,10 @@ class Document(Binding):
         return root
 
     def replycontent(self, method, body):
-        if method.soap.output.body.wrapped:
+        if method.soap.output.body.wrapped and body:
             return body[0].children
+        elif method.soap.output.body.wrapped:
+            return []
         return body.children
 
     def document(self, wrapper):

--- a/tests/test_reply_handling.py
+++ b/tests/test_reply_handling.py
@@ -244,6 +244,11 @@ def test_invalid_fault_namespace(monkeypatch):
         assert reason == "trla baba lan"
 
 
+def test_empty_list_result_response():
+    client = testutils.client_from_wsdl(_complex_sample_wsdl)
+
+    response = client.service.f(__inject=dict(reply=_empty_reply))
+
 def test_missing_wrapper_response():
     """
     Suds library's automatic structure unwrapping should not be applied to
@@ -512,3 +517,57 @@ _wsdl__simple_f = testutils.wsdl("""\
           </xsd:sequence>
         </xsd:complexType>
       </xsd:element>""", output="fResponse", operation_name="f")
+
+_complex_sample_wsdl = testutils.wsdl("""\
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="urn:microsoft-dynamics-schemas/page/customer" targetNamespace="urn:microsoft-dynamics-schemas/page/customer">
+  <types>
+    <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="urn:microsoft-dynamics-schemas/page/customer">
+      <xsd:element name="Read">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element minOccurs="1" maxOccurs="1" name="No" type="xsd:string"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="Read_Result">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element minOccurs="0" maxOccurs="1" name="Customer" type="xsd:string"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:schema>
+  </types>
+  <message name="Read_Result">
+    <part name="parameters" element="tns:Read_Result"/>
+  </message>
+  <portType name="Customer_Port">
+    <operation name="Read">
+      <input name="Read" message="tns:Read"/>
+      <output name="Read_Result" message="tns:Read_Result"/>
+    </operation>
+  </portType>
+  <binding name="Customer_Binding" type="tns:Customer_Port">
+    <binding xmlns="http://schemas.xmlsoap.org/wsdl/soap/" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="Read">
+      <operation xmlns="http://schemas.xmlsoap.org/wsdl/soap/" soapAction="urn:microsoft-dynamics-schemas/page/customer:Read" style="document"/>
+      <input name="Read">
+        <body xmlns="http://schemas.xmlsoap.org/wsdl/soap/" use="literal"/>
+      </input>
+      <output name="Read_Result">
+        <body xmlns="http://schemas.xmlsoap.org/wsdl/soap/" use="literal"/>
+      </output>
+    </operation>
+  </binding>
+  <service name="Customer_Service">
+    <port name="Customer_Port" binding="tns:Customer_Binding">
+      <address xmlns="http://schemas.xmlsoap.org/wsdl/soap/" location="https://localhost:8000/Page/Customer"/>
+    </port>
+  </service>
+</definitions>""")
+
+_empty_reply = suds.byte_str("""\
+<?xml version="1.0"?>
+<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+  <env:Body/>
+</env:Envelope>""")


### PR DESCRIPTION
This test (unfortunately) does not touch the right code path (`replycontent` in `suds/bindings/document.py`)