### PR TITLE
Rename package, fix namespace fallback

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -353,7 +353,7 @@ licensed under LGPL (see the LICENSE.txt file included in the
 distribution).
 """
 
-package_name = "suds-ableton"
+forked_package_name = package_name = "suds-ableton"
 version_tag = safe_version(__version__)
 project_url = "https://github.com/AbletonAG/suds-ableton"
 base_download_url = project_url + "/archive"

--- a/suds/bindings/binding.py
+++ b/suds/bindings/binding.py
@@ -147,11 +147,11 @@ class Binding(object):
 
         """
         soapenv = replyroot.getChild("Envelope", envns)
-        if not soapenv:
+        if soapenv is None:
             soapenv = replyroot.getChild("Envelope", envns12)
         soapenv.promotePrefixes()
         soapbody = soapenv.getChild("Body", envns)
-        if not soapbody:
+        if soapbody is None:
             soapbody = soapenv.getChild("Body", envns12)
         soapbody = self.multiref.process(soapbody)
         nodes = self.replycontent(method, soapbody)

--- a/suds/version.py
+++ b/suds/version.py
@@ -22,5 +22,5 @@ See the setup.py script for more detailed information.
 
 """
 
-__version__ = "1.2.0"
+__version__ = "1.2.1.dev1"
 __build__ = ""

--- a/suds/version.py
+++ b/suds/version.py
@@ -22,5 +22,5 @@ See the setup.py script for more detailed information.
 
 """
 
-__version__ = "1.2.1.dev1"
+__version__ = "1.2.1+ablfix03"
 __build__ = ""


### PR DESCRIPTION
When the body in an envelope is empty, suds will try a different namespace to find a non-empty body. Problem is that we receive bodies with no children from Business Central that are also considered empty by virtue of the resulting body having a length of zero. Instead of checking for the truthyness of the body (and thus number of children) we check whether the body is `None` instead.